### PR TITLE
fix: add matplotlib to requirements-dev.txt for notebook plotting

### DIFF
--- a/backend/requirements-dev.txt
+++ b/backend/requirements-dev.txt
@@ -9,3 +9,5 @@ flake8==7.0.0
 
 # Jupyter notebooks — for the experiments/ folder
 jupyter==1.0.0
+# Plotting — required for training loss visualization in notebooks
+matplotlib>=3.7.0


### PR DESCRIPTION
## What does this PR do?
Adds matplotlib to backend/requirements-dev.txt so contributors 
can run the Jupyter notebooks without hitting a ModuleNotFoundError 
when plotting training loss in Step 6 of 01_baseline_lstm.ipynb.

## Related issue
Closes #3

## Type of change
- [x] 🐛 Bug fix

## Checklist
- [x] My code runs without errors
- [ ] I have added or updated tests
- [x] All existing tests pass (`pytest tests/`)
- [x] I have commented my code so others can understand it
- [x] My branch is up to date with `main`

## Screenshots or outputs (if relevant)
Successfully installed matplotlib-3.11.0 via:
pip install -r backend/requirements-dev.txt